### PR TITLE
Keep template to allow restarting the container

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-envtpl /etc/collectd/collectd.conf.tpl
+envtpl --keep-template /etc/collectd/collectd.conf.tpl
 
 collectd -f


### PR DESCRIPTION
The image can only be started once. The config template gets deleted on startup so subsequent starts or restarts (e.g. when Docker or the host is restarted) will fail with `Error: [Errno 2] No such file or directory: '/etc/collectd/collectd.conf.tpl'` and the only workaround is to `docker stop && docker rm` the container. This PR should fix that.
